### PR TITLE
docs: add IMU driver to implementation plan

### DIFF
--- a/docs/en/drivers/01-driver-implementation-plan.md
+++ b/docs/en/drivers/01-driver-implementation-plan.md
@@ -15,10 +15,11 @@ Implementation plan for NuttX device drivers to control SPIKE Prime Hub hardware
 | 3 | H-Bridge Motor Control | `/dev/legomotor[N]` | **P0** | TIM1/3/4 PWM |
 | 4 | Sensor Data Readout | `/dev/legosensor[N]` | **P1** | LUMP |
 | 5 | TLC5955 LED Driver | `/dev/leds` | **P1** | SPI1 |
-| 6 | USB CDC/ACM Console | `/dev/ttyACM0` | **Done** | OTG FS |
-| 7 | W25Q256 SPI Flash | `/dev/mtdblock0` | **P2** | SPI2 |
-| 8 | Power Management | (board init) | **P0** | PA13/PA14 GPIO |
-| 9 | Bluetooth (TBD) | — | **P3** | USART2 |
+| 6 | IMU (LSM6DS3TR-C) | `/dev/imu0` | **P1** | I2C2 |
+| 7 | USB CDC/ACM Console | `/dev/ttyACM0` | **Done** | OTG FS |
+| 8 | W25Q256 SPI Flash | `/dev/mtdblock0` | **P2** | SPI2 |
+| 9 | Power Management | (board init) | **P0** | PA13/PA14 GPIO |
+| 10 | Bluetooth (TBD) | — | **P3** | USART2 |
 
 ### Priority Definitions
 
@@ -126,6 +127,19 @@ pybricks reference: `led_dual_pwm.c`, bringup research: `10-tlc5955-led-driver.m
 - LATCH pin: GPIO controlled
 - NuttX `/dev/leds` or `/dev/userleds` interface
 
+#### 2c. IMU (LSM6DS3TR-C)
+
+pybricks reference: `imu_lsm6ds3tr_c_stm32.c`
+
+- ST 6-axis IMU (3-axis accelerometer + 3-axis gyroscope)
+- Connected via I2C2
+  - SCL: PB10 (AF4)
+  - SDA: PB3 (AF9)
+  - INT1: PB4 (EXTI4, data-ready interrupt)
+- Axis sign correction: X=-1, Y=+1, Z=-1 (Hub PCB mounting orientation)
+- Can leverage NuttX sensor driver framework (`CONFIG_SENSORS_LSM6DSL` etc.)
+- Exposed as `/dev/imu0` or `/dev/accel0` + `/dev/gyro0`
+
 ### Phase 3: Storage (P2)
 
 #### 3a. W25Q256 SPI NOR Flash
@@ -157,6 +171,7 @@ boards/spike-prime-hub/src/
   stm32_legoport.c      # I/O port manager (DCM)
   stm32_legomotor.c     # H-Bridge motor control
   stm32_tlc5955.c       # TLC5955 LED driver
+  stm32_lsm6ds3.c       # IMU (LSM6DS3TR-C) init
 
 drivers/lego/           # NuttX generic drivers (apps/ or in-board)
   lump_uart.c           # LUMP UART protocol engine
@@ -212,6 +227,7 @@ Phase 1d: H-Bridge Motor       ← After 1c
     ↓
 Phase 2a: Sensor Readout       ← After 1c
 Phase 2b: TLC5955 LED          ← Independent
+Phase 2c: IMU                  ← Independent (I2C2)
     ↓
 Phase 3a: W25Q256 Flash        ← Independent
     ↓

--- a/docs/en/drivers/01-driver-implementation-plan.md
+++ b/docs/en/drivers/01-driver-implementation-plan.md
@@ -16,10 +16,13 @@ Implementation plan for NuttX device drivers to control SPIKE Prime Hub hardware
 | 4 | Sensor Data Readout | `/dev/legosensor[N]` | **P1** | LUMP |
 | 5 | TLC5955 LED Driver | `/dev/leds` | **P1** | SPI1 |
 | 6 | IMU (LSM6DS3TR-C) | `/dev/imu0` | **P1** | I2C2 |
-| 7 | USB CDC/ACM Console | `/dev/ttyACM0` | **Done** | OTG FS |
-| 8 | W25Q256 SPI Flash | `/dev/mtdblock0` | **P2** | SPI2 |
-| 9 | Power Management | (board init) | **P0** | PA13/PA14 GPIO |
-| 10 | Bluetooth (TBD) | — | **P3** | USART2 |
+| 7 | DAC Audio | `/dev/dac0` | **P1** | DAC1 + TIM6 |
+| 8 | ADC Battery Monitor | `/dev/adc0` | **P1** | ADC1 (6ch) + DMA2 |
+| 9 | USB CDC/ACM Console | `/dev/ttyACM0` | **Done** | OTG FS |
+| 10 | W25Q256 SPI Flash | `/dev/mtdblock0` | **P2** | SPI2 |
+| 11 | Power Management | (board init) | **P0** | PA13/PA14 GPIO |
+| 12 | MP2639A Charger | (board internal) | **P2** | TIM5 PWM + ADC |
+| 13 | Bluetooth (CC256x) | — | **P3** | USART2 + DMA |
 
 ### Priority Definitions
 
@@ -140,7 +143,35 @@ pybricks reference: `imu_lsm6ds3tr_c_stm32.c`
 - Can leverage NuttX sensor driver framework (`CONFIG_SENSORS_LSM6DSL` etc.)
 - Exposed as `/dev/imu0` or `/dev/accel0` + `/dev/gyro0`
 
-### Phase 3: Storage (P2)
+#### 2d. DAC Audio
+
+pybricks reference: `sound.c`
+
+- Analog audio output via DAC1 CH1 (PA4)
+- Speaker enable: PC10 (GPIO HIGH to enable)
+- TIM6 TRGO for sample rate control
+- DMA1_Stream5 (CH7) for buffer transfer
+- Implement using NuttX audio or DAC driver
+
+#### 2e. ADC Battery Monitor & Button Input
+
+pybricks reference: `battery_adc.c`, `button_resistor_ladder.c`
+
+- ADC1 6 channels + DMA2_Stream0 for periodic sampling
+- TIM2 trigger for ADC conversion
+
+| Channel | Pin | Purpose |
+|---|---|---|
+| CH10 | PC0 | Battery current (max 7300mA) |
+| CH11 | PC1 | Battery voltage (max 9900mV) |
+| CH8 | PB0 | Battery temperature (NTC thermistor) |
+| CH3 | PA3 | USB charger input current |
+| CH14 | PC4 | Charge status (resistor ladder) |
+| CH1 | PA1 | **Button pad** (resistor ladder, multiple buttons) |
+
+**Note**: Hub button input uses **ADC resistor ladder**, not GPIO. Button identity is determined from PA1 voltage level. Center button, Bluetooth button, etc. are multiplexed on a single ADC channel.
+
+### Phase 3: Storage & Charging (P2)
 
 #### 3a. W25Q256 SPI NOR Flash
 
@@ -152,11 +183,20 @@ bringup research: `11-w25q256-flash-driver.md`
 - Format with LittleFS or SmartFS
 - Storage for user programs and data logs
 
+#### 3b. MP2639A Charger Control
+
+- Battery charger IC (MP2639A)
+- Charge current setting: TIM5 CH1 (PA0) PWM (96kHz)
+- Charge status monitoring: ADC resistor ladder (CH14/PC4) 8-level detection
+- Charge complete / error detection
+
 ### Phase 4: Wireless (P3)
 
-#### 4a. Bluetooth
+#### 4a. Bluetooth (CC256x)
 
-- BLE module via USART2 (PD5/PD6)
+- CC256x BLE chip
+- USART2 (PD5/PD6) + flow control (PD3/PD4)
+- DMA1_Stream6/7 for TX/RX
 - Details TBD
 
 ---
@@ -172,6 +212,9 @@ boards/spike-prime-hub/src/
   stm32_legomotor.c     # H-Bridge motor control
   stm32_tlc5955.c       # TLC5955 LED driver
   stm32_lsm6ds3.c       # IMU (LSM6DS3TR-C) init
+  stm32_audio.c         # DAC audio + speaker control
+  stm32_battery.c       # ADC battery monitor + button input
+  stm32_charger.c       # MP2639A charger control
 
 drivers/lego/           # NuttX generic drivers (apps/ or in-board)
   lump_uart.c           # LUMP UART protocol engine
@@ -228,8 +271,11 @@ Phase 1d: H-Bridge Motor       ← After 1c
 Phase 2a: Sensor Readout       ← After 1c
 Phase 2b: TLC5955 LED          ← Independent
 Phase 2c: IMU                  ← Independent (I2C2)
+Phase 2d: DAC Audio            ← Independent (DAC1 + TIM6)
+Phase 2e: ADC Battery          ← Independent (ADC1 + DMA2)
     ↓
 Phase 3a: W25Q256 Flash        ← Independent
+Phase 3b: MP2639A Charger      ← After 2e (ADC)
     ↓
 Phase 4a: Bluetooth            ← Future
 ```

--- a/docs/ja/drivers/01-driver-implementation-plan.md
+++ b/docs/ja/drivers/01-driver-implementation-plan.md
@@ -16,10 +16,13 @@ SPIKE Prime Hub 上で NuttX からハードウェアを制御するためのデ
 | 4 | センサーデータ読取り | `/dev/legosensor[N]` | **P1** | LUMP |
 | 5 | TLC5955 LED ドライバ | `/dev/leds` | **P1** | SPI1 |
 | 6 | IMU (LSM6DS3TR-C) | `/dev/imu0` | **P1** | I2C2 |
-| 7 | USB CDC/ACM コンソール | `/dev/ttyACM0` | **済** | OTG FS |
-| 8 | W25Q256 SPI Flash | `/dev/mtdblock0` | **P2** | SPI2 |
-| 9 | 電源管理 | (board 初期化) | **P0** | PA13/PA14 GPIO |
-| 10 | Bluetooth (TBD) | — | **P3** | USART2 |
+| 7 | DAC オーディオ | `/dev/dac0` | **P1** | DAC1 + TIM6 |
+| 8 | ADC バッテリー監視 | `/dev/adc0` | **P1** | ADC1 (6ch) + DMA2 |
+| 9 | USB CDC/ACM コンソール | `/dev/ttyACM0` | **済** | OTG FS |
+| 10 | W25Q256 SPI Flash | `/dev/mtdblock0` | **P2** | SPI2 |
+| 11 | 電源管理 | (board 初期化) | **P0** | PA13/PA14 GPIO |
+| 12 | MP2639A 充電制御 | (board 内部) | **P2** | TIM5 PWM + ADC |
+| 13 | Bluetooth (CC256x) | — | **P3** | USART2 + DMA |
 
 ### 優先度定義
 
@@ -140,7 +143,35 @@ pybricks 参照: `imu_lsm6ds3tr_c_stm32.c`
 - NuttX の sensor ドライバフレームワーク (`CONFIG_SENSORS_LSM6DSL` 等) を活用可能
 - `/dev/imu0` または `/dev/accel0` + `/dev/gyro0` として公開
 
-### Phase 3: ストレージ (P2)
+#### 2d. DAC オーディオ
+
+pybricks 参照: `sound.c`
+
+- DAC1 CH1 (PA4) でアナログ音声信号を出力
+- スピーカー有効化: PC10 (GPIO HIGH で有効)
+- TIM6 TRGO でサンプルレート制御
+- DMA1_Stream5 (CH7) でバッファ転送
+- NuttX の audio ドライバまたは DAC ドライバで実装
+
+#### 2e. ADC バッテリー監視・ボタン入力
+
+pybricks 参照: `battery_adc.c`, `button_resistor_ladder.c`
+
+- ADC1 6 チャンネル + DMA2_Stream0 で周期的サンプリング
+- TIM2 トリガで ADC 変換開始
+
+| チャンネル | ピン | 用途 |
+|---|---|---|
+| CH10 | PC0 | バッテリー電流 (最大 7300mA) |
+| CH11 | PC1 | バッテリー電圧 (最大 9900mV) |
+| CH8 | PB0 | バッテリー温度 (NTC サーミスタ) |
+| CH3 | PA3 | USB 充電入力電流 |
+| CH14 | PC4 | 充電状態 (抵抗ラダー) |
+| CH1 | PA1 | **ボタンパッド** (抵抗ラダーで複数ボタン検出) |
+
+**注意**: Hub のボタン入力は GPIO ではなく **ADC 抵抗ラダー** 方式。PA1 の電圧レベルから押下ボタンを判定する。Center ボタン、Bluetooth ボタン等を 1 本の ADC チャンネルで多重化。
+
+### Phase 3: ストレージ・充電 (P2)
 
 #### 3a. W25Q256 SPI NOR Flash
 
@@ -152,11 +183,20 @@ bringup 調査: `11-w25q256-flash-driver.md`
 - LittleFS または SmartFS でフォーマット
 - ユーザープログラム・データログの保存先
 
+#### 3b. MP2639A 充電制御
+
+- バッテリー充電 IC (MP2639A)
+- 充電電流設定: TIM5 CH1 (PA0) で PWM 制御 (96kHz)
+- 充電状態監視: ADC 抵抗ラダー (CH14/PC4) で 8 段階検出
+- 充電完了・エラー検出
+
 ### Phase 4: 無線通信 (P3)
 
-#### 4a. Bluetooth
+#### 4a. Bluetooth (CC256x)
 
-- USART2 (PD5/PD6) 経由の BLE モジュール
+- CC256x BLE チップ
+- USART2 (PD5/PD6) + フロー制御 (PD3/PD4)
+- DMA1_Stream6/7 で送受信
 - 詳細は TBD
 
 ---
@@ -172,6 +212,9 @@ boards/spike-prime-hub/src/
   stm32_legomotor.c     # H-Bridge モーター制御
   stm32_tlc5955.c       # TLC5955 LED ドライバ
   stm32_lsm6ds3.c       # IMU (LSM6DS3TR-C) 初期化
+  stm32_audio.c         # DAC オーディオ + スピーカー制御
+  stm32_battery.c       # ADC バッテリー監視 + ボタン入力
+  stm32_charger.c       # MP2639A 充電制御
 
 drivers/lego/           # NuttX 汎用ドライバ (apps/ または board 内)
   lump_uart.c           # LUMP UART プロトコルエンジン
@@ -228,8 +271,11 @@ Phase 1d: H-Bridge モーター ← 1c 完了後
 Phase 2a: センサー読取り    ← 1c 完了後
 Phase 2b: TLC5955 LED       ← 独立実装可能
 Phase 2c: IMU               ← 独立実装可能 (I2C2)
+Phase 2d: DAC オーディオ    ← 独立実装可能 (DAC1 + TIM6)
+Phase 2e: ADC バッテリー    ← 独立実装可能 (ADC1 + DMA2)
     ↓
 Phase 3a: W25Q256 Flash     ← 独立実装可能
+Phase 3b: MP2639A 充電      ← 2e (ADC) 完了後
     ↓
 Phase 4a: Bluetooth         ← 将来
 ```

--- a/docs/ja/drivers/01-driver-implementation-plan.md
+++ b/docs/ja/drivers/01-driver-implementation-plan.md
@@ -15,10 +15,11 @@ SPIKE Prime Hub 上で NuttX からハードウェアを制御するためのデ
 | 3 | H-Bridge モーター制御 | `/dev/legomotor[N]` | **P0** | TIM1/3/4 PWM |
 | 4 | センサーデータ読取り | `/dev/legosensor[N]` | **P1** | LUMP |
 | 5 | TLC5955 LED ドライバ | `/dev/leds` | **P1** | SPI1 |
-| 6 | USB CDC/ACM コンソール | `/dev/ttyACM0` | **済** | OTG FS |
-| 7 | W25Q256 SPI Flash | `/dev/mtdblock0` | **P2** | SPI2 |
-| 8 | 電源管理 | (board 初期化) | **P0** | PA13/PA14 GPIO |
-| 9 | Bluetooth (TBD) | — | **P3** | USART2 |
+| 6 | IMU (LSM6DS3TR-C) | `/dev/imu0` | **P1** | I2C2 |
+| 7 | USB CDC/ACM コンソール | `/dev/ttyACM0` | **済** | OTG FS |
+| 8 | W25Q256 SPI Flash | `/dev/mtdblock0` | **P2** | SPI2 |
+| 9 | 電源管理 | (board 初期化) | **P0** | PA13/PA14 GPIO |
+| 10 | Bluetooth (TBD) | — | **P3** | USART2 |
 
 ### 優先度定義
 
@@ -126,6 +127,19 @@ pybricks 参照: `led_dual_pwm.c`, bringup 調査: `10-tlc5955-led-driver.md`
 - LATCH ピン: GPIO で制御
 - NuttX の `/dev/leds` または `/dev/userleds` インターフェース
 
+#### 2c. IMU (LSM6DS3TR-C)
+
+pybricks 参照: `imu_lsm6ds3tr_c_stm32.c`
+
+- ST 製 6 軸 IMU（3 軸加速度 + 3 軸ジャイロ）
+- I2C2 経由で接続
+  - SCL: PB10 (AF4)
+  - SDA: PB3 (AF9)
+  - INT1: PB4 (EXTI4, データレディ割り込み)
+- 軸符号補正: X=-1, Y=+1, Z=-1（Hub 基板実装向き）
+- NuttX の sensor ドライバフレームワーク (`CONFIG_SENSORS_LSM6DSL` 等) を活用可能
+- `/dev/imu0` または `/dev/accel0` + `/dev/gyro0` として公開
+
 ### Phase 3: ストレージ (P2)
 
 #### 3a. W25Q256 SPI NOR Flash
@@ -157,6 +171,7 @@ boards/spike-prime-hub/src/
   stm32_legoport.c      # I/O ポートマネージャ (DCM)
   stm32_legomotor.c     # H-Bridge モーター制御
   stm32_tlc5955.c       # TLC5955 LED ドライバ
+  stm32_lsm6ds3.c       # IMU (LSM6DS3TR-C) 初期化
 
 drivers/lego/           # NuttX 汎用ドライバ (apps/ または board 内)
   lump_uart.c           # LUMP UART プロトコルエンジン
@@ -212,6 +227,7 @@ Phase 1d: H-Bridge モーター ← 1c 完了後
     ↓
 Phase 2a: センサー読取り    ← 1c 完了後
 Phase 2b: TLC5955 LED       ← 独立実装可能
+Phase 2c: IMU               ← 独立実装可能 (I2C2)
     ↓
 Phase 3a: W25Q256 Flash     ← 独立実装可能
     ↓


### PR DESCRIPTION
## Summary
- ドライバ実装計画に IMU (LSM6DS3TR-C) を追加
  - チップ: ST LSM6DS3TR-C (6 軸 IMU: 加速度 + ジャイロ)
  - バス: I2C2 (SCL=PB10/AF4, SDA=PB3/AF9, INT1=PB4/EXTI4)
  - 軸符号: X=-1, Y=+1, Z=-1
  - Phase 2c (P1)、I2C2 のみで独立実装可能

## Test plan
- [x] ドキュメント内容のレビュー（日英）

🤖 Generated with [Claude Code](https://claude.com/claude-code)